### PR TITLE
PatchSave overhaul, LZ4DecomprsssionStream tweak

### DIFF
--- a/CompressSave/CompressSave.cs
+++ b/CompressSave/CompressSave.cs
@@ -1,4 +1,3 @@
-
 using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
@@ -6,57 +5,51 @@ using LZ4;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace DSP_Plugin
 {
-	[BepInPlugin("com.bluedoom.plugin.Dyson.CompressSave", "CompressSave", "1.1.3")]
+	[BepInPlugin("com.bluedoom.plugin.Dyson.CompressSave", "CompressSave", "1.1.5")]
 	public class CompressSave : BaseUnityPlugin
 	{
-        List<Harmony> patchList;
-        Harmony patchUILoadGameInstance;
-
-        private void Start()
+        Harmony harmony;
+        public void Awake()
         {
-            //SaveUtil.logger = Logger;
-            if(LZ4API.Avaliable)
+            harmony = new Harmony("com.bluedoom.plugin.Dyson.CompressSave");
+            SaveUtil.logger = Logger;
+            if (LZ4API.Avaliable)
             {
-                BepInEx.Logging.Logger.Sources.Add(SaveUtil.logger);
-
-                if (GameConfig.gameVersion == SaveUtil.VerifiedVersion)
-                {
-                    patchList = new List<Harmony>
-                    {
-                        Harmony.CreateAndPatchAll(typeof(PatchSave), null),
-                        Harmony.CreateAndPatchAll(typeof(PatchUISaveGame), null),
-                    };
+                if (GameConfig.gameVersion != SaveUtil.VerifiedVersion)
+                {                    
+                    SaveUtil.logger.LogWarning($"Save versions are not matched. Expect:{SaveUtil.VerifiedVersion},Current:{GameConfig.gameVersion}");
                 }
-                else
-                {
-                    SaveUtil.logger.LogWarning($"Version Verify Failed. Expect:{SaveUtil.VerifiedVersion},Current:{GameConfig.gameVersion}");
-                }
-                patchUILoadGameInstance = Harmony.CreateAndPatchAll(typeof(PatchUILoadGame), null);
+                harmony.PatchAll(typeof(PatchSave));
+                if (PatchSave.EnableCompress)
+                    harmony.PatchAll(typeof(PatchUISaveGame));
+                harmony.PatchAll(typeof(PatchUILoadGame));
             }
+            else
+                SaveUtil.logger.LogWarning("LZ4.dll is not avaliable.");
         }
 
-		void OnDestroy()
+        public void OnDestroy()
         {
-            BepInEx.Logging.Logger.Sources.Remove(SaveUtil.logger);
             PatchUISaveGame.OnDestroy();
             PatchUILoadGame.OnDestroy();
-            patchUILoadGameInstance?.UnpatchSelf();
-            patchList?.ForEach(h => h?.UnpatchSelf());
-            patchList?.Clear();
+            harmony.UnpatchSelf();
         }
 	}
 
 	class PatchSave
 	{
-        const bool SkipHostFunc = false;
-        const bool RunHostFunc = true;
 		const long MB = 1024 * 1024;
-		static LZ4CompressionStream.CompressBuffer compressBuffer = LZ4CompressionStream.CreateBuffer((int)MB);
+		static LZ4CompressionStream.CompressBuffer compressBuffer = LZ4CompressionStream.CreateBuffer((int)MB*2); //Bigger buffer for GS2 compatible
         public static bool UseCompressSave = false;
+        static Stream lzstream = null;
+        public static bool EnableCompress;
+        public static bool EnableDecompress;
 
         private static void WriteHeader(FileStream fileStream)
         {
@@ -64,278 +57,174 @@ namespace DSP_Plugin
                 fileStream.WriteByte(0xCC);
         }
 
-
-        [HarmonyPatch(typeof(GameSave), "AutoSave"),HarmonyPrefix]
-        static void BeforeAutoSave()
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(GameSave), "AutoSave")]
+        [HarmonyPatch(typeof(GameSave), "SaveAsLastExit")]
+        public static void BeforeAutoSave()
         {
-            UseCompressSave = true;
+            UseCompressSave = EnableCompress;
         }
 
-		[HarmonyPatch(typeof(GameSave), "SaveCurrentGame"), HarmonyPrefix]
-		static bool Save_Wrap(ref bool __result, string saveName)
+        [HarmonyPatch(typeof(GameSave), "SaveCurrentGame"), HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> SaveCurrentGame_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
         {
-            if (SaveUtil.VerifiedVersion != GameConfig.gameVersion)
-            {
-                //logger.LogWarning($"VersionVerify Failed. Expect:{VerifiedVersion},Current:{GameConfig.gameVersion}");
-                return RunHostFunc;
-            }
-            if (!UseCompressSave) return RunHostFunc;
-
-			__result = Save(saveName);
-			return !__result;
-        }
-		public static bool Save(string saveName)
-		{
-            PARTNER.UploadClusterGenerationToGalaxyServer(GameMain.data);
-            HighStopwatch highStopwatch = new HighStopwatch();
-			highStopwatch.Begin();
-			if (DSPGame.Game == null)
-			{
-				Debug.LogError("No game to save");
-				return false;
-
-			}
-			GameCamera.CaptureSaveScreenShot();
-			saveName = saveName.ValidFileName();
-			string path = GameConfig.gameSaveFolder + saveName + GameSave.saveExt;
-			try
-			{
-				using (FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
-				{
-                    WriteHeader(fileStream);
-
-                    using (LZ4CompressionStream lzstream = new LZ4CompressionStream(fileStream, compressBuffer, true))
-                    using (BinaryWriter binaryWriter = lzstream.CreateBufferedWriter())
-					{
-                        binaryWriter.Write('V');
-                        binaryWriter.Write('F');
-                        binaryWriter.Write('S');
-                        binaryWriter.Write('A');
-                        binaryWriter.Write('V');
-                        binaryWriter.Write('E');
-                        binaryWriter.Write(0L);
-                        binaryWriter.Write(5);
-                        binaryWriter.Write(GameConfig.gameVersion.Major);
-                        binaryWriter.Write(GameConfig.gameVersion.Minor);
-                        binaryWriter.Write(GameConfig.gameVersion.Release);
-                        binaryWriter.Write(GameMain.gameTick);
-                        long ticks = DateTime.Now.Ticks;
-                        binaryWriter.Write(ticks);
-                        GameData data = GameMain.data;
-                        if (data.screenShot != null)
-                        {
-                            int num = data.screenShot.Length;
-                            binaryWriter.Write(num);
-                            binaryWriter.Write(data.screenShot, 0, num);
-                        }
-                        else
-                        {
-                            binaryWriter.Write(0);
-                        }
-                        ulong num2 = 0uL;
-                        DysonSphere[] dysonSpheres = data.dysonSpheres;
-                        int num3 = dysonSpheres.Length;
-                        for (int i = 0; i < num3; i++)
-                        {
-                            if (dysonSpheres[i] != null)
-                            {
-								num2 += (ulong)dysonSpheres[i].energyGenCurrentTick;
-                            }
-                        }
-                        data.account.Export(binaryWriter);
-                        binaryWriter.Write(num2);
-                        data.Export(binaryWriter);
-                        //long position = fileStream.Position;
-                        //fileStream.Seek(6L, SeekOrigin.Begin);
-                        //binaryWriter.Write(position);
-                    }
-				}
-				double duration = highStopwatch.duration;
-				Debug.Log("Game save file wrote, time cost: " + duration + "s");
-				STEAMX.UploadScoreToLeaderboard(GameMain.data);
-				return true;
-			}
-			catch (Exception exception)
-			{
-				Debug.LogException(exception);
-				return false;
-			}
-			
-		}
-
-        [HarmonyPatch(typeof(GameSave), "ReadHeader"), HarmonyPrefix]
-        static bool ReadHeader_Wrap(ref GameSaveHeader __result, string saveName, bool readImage)
-        {
-            __result = ReadHeader(saveName, readImage);
-            return __result == null;
-        }
-
-        static bool VerifyHeader(BinaryReader binaryReader)
-        {
-            return binaryReader.ReadChar() == 'V'
-             && binaryReader.ReadChar() == 'F'
-             && binaryReader.ReadChar() == 'S'
-             && binaryReader.ReadChar() == 'A'
-             && binaryReader.ReadChar() == 'V'
-             && binaryReader.ReadChar() == 'E';
-        }
-
-        static GameSaveHeader ReadHeader(string saveName, bool readImage)
-        {
-            if (saveName == null)
-            {
-                return null;
-            }
-            saveName = saveName.ValidFileName();
-            string path = GameConfig.gameSaveFolder + saveName + GameSave.saveExt;
-            if (!File.Exists(path))
-            {
-                return null;
-            }
-            GameSaveHeader result;
+            /* BinaryWriter binaryWriter = new BinaryWriter(fileStream); => Create lzstream and replace binaryWriter.
+             * fileStream.Seek(6L, SeekOrigin.Begin); binaryWriter.Write(position); => Disable seek&write function.
+             * binaryWriter.Dispose(); => Dispose lzstream before fileStream close.
+            */
             try
             {
-                CompressionGameSaveHeader gameSaveHeader = new CompressionGameSaveHeader();
-                using (FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
-                {
-                    if (SaveUtil.IsCompressedSave(fileStream))
-                    {
-                        gameSaveHeader.IsCompressed = true;
-                    }
-                    else
-                    {
-                        return null; 
-                    }
-                    using (var lzstream = new LZ4DecompressionStream(fileStream))
-                    using (BinaryReader binaryReader = new BinaryReader(lzstream))
-                    {
-                        if (!VerifyHeader(binaryReader))
-                        {
-                            Debug.LogError("Invalid game save file");
-                            return null;
-                        }
-
-                        binaryReader.ReadInt64();
-                        gameSaveHeader.fileSize = fileStream.Length;
-        
-                        gameSaveHeader.headerVersion = binaryReader.ReadInt32();
-                        if (gameSaveHeader.headerVersion < 1)
-                        {
-                            return null;
-                        }
-                        gameSaveHeader.gameClientVersion.Major = binaryReader.ReadInt32();
-                        gameSaveHeader.gameClientVersion.Minor = binaryReader.ReadInt32();
-                        gameSaveHeader.gameClientVersion.Release = binaryReader.ReadInt32();
-                        gameSaveHeader.gameTick = binaryReader.ReadInt64();
-                        long value = binaryReader.ReadInt64();
-                        gameSaveHeader.saveTime = default(DateTime).AddTicks(value);
-                        if (readImage)
-                        {
-                            int count = binaryReader.ReadInt32();
-                            gameSaveHeader.themeImage = binaryReader.ReadBytes(count);
-                        }
-                        if (gameSaveHeader.headerVersion >= 5)
-                        {
-                            gameSaveHeader.accountData.Import(binaryReader);
-                            gameSaveHeader.clusterGeneration = binaryReader.ReadUInt64();
-                        }
-                        else
-                        {
-                            gameSaveHeader.accountData = AccountData.NULL;
-                            gameSaveHeader.clusterGeneration = 0UL;
-                        }
-                    }
-                }
-                result = gameSaveHeader;
+                var matcher = new CodeMatcher(instructions, iLGenerator)
+                    .MatchForward(false, new CodeMatch(OpCodes.Newobj, AccessTools.Constructor(typeof(BinaryWriter), new Type[] { typeof(FileStream) })))
+                    .Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "CreateBinaryWriter"))
+                    .MatchForward(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(System.IO.Stream), "Seek")))
+                    .Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "FileLengthWrite0"))
+                    .MatchForward(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(BinaryWriter), "Write", new Type[] { typeof(long) })))
+                    .Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "FileLengthWrite1"))
+                    .MatchForward(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(System.IDisposable), "Dispose")))
+                    .Advance(1)
+                    .Insert(new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "DisposeLzstream")));
+                EnableCompress = true;
+                return matcher.InstructionEnumeration();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                result = null;
+                SaveUtil.logger.LogError("SaveCurrentGame_Transpiler failed. Mod version not compatible with game version.");
+                SaveUtil.logger.LogError(ex);
             }
-            return result;
+            return instructions;
         }
 
-        [HarmonyPatch(typeof(GameSave), "LoadCurrentGame"), HarmonyPrefix]
-        static bool Load_Wrap(ref bool __result, string saveName)
+        public static BinaryWriter CreateBinaryWriter(FileStream fileStream)
         {
-            __result = LoadCurrentGame(ref saveName);
-            return !__result;
+            if (UseCompressSave)
+            {
+                SaveUtil.logger.LogDebug("Using compress save...");
+                WriteHeader(fileStream);
+                lzstream = new LZ4CompressionStream(fileStream, compressBuffer, true); //need to dispose after use
+                return ((LZ4CompressionStream)lzstream).CreateBufferedWriter();
+            }
+            SaveUtil.logger.LogDebug("Using normal save...");
+            return new BinaryWriter(fileStream);
         }
 
-        static bool LoadCurrentGame(ref string saveName)
+        public static long FileLengthWrite0(FileStream fileStream, long offset, SeekOrigin origin)
         {
-            if (DSPGame.Game == null)
+            if (!UseCompressSave)
+                return fileStream.Seek(offset, origin);
+            return 0L;
+        }
+
+        public static void FileLengthWrite1(BinaryWriter binaryWriter, long value)
+        {
+            if (!UseCompressSave)
+                binaryWriter.Write(value);
+        }
+
+        public static void DisposeLzstream()
+        {
+            if (UseCompressSave)
             {
-                Debug.LogError("No game to load");
-                return false;
+                bool writeflag = lzstream.CanWrite;
+                lzstream?.Dispose(); //Dispose need to be done before fstream closed.
+                lzstream = null;
+                if (writeflag) //Reset UseCompressSave after writing to file
+                    UseCompressSave = false;                
+                return;
             }
-            saveName = saveName.ValidFileName();
-            string path = GameConfig.gameSaveFolder + saveName + GameSave.saveExt;
-            if (!File.Exists(path))
-            {
-                Debug.LogError("Game save not exist");
-                return false;
-            }
-            bool result;
+        }
+
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(GameSave), "LoadCurrentGame")]
+        [HarmonyPatch(typeof(GameSave), "LoadGameDesc")]
+        [HarmonyPatch(typeof(GameSave), "ReadHeader")]
+        public static IEnumerable<CodeInstruction> LoadCurrentGame_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        {
+            /* using (BinaryReader binaryReader = new BinaryReader(fileStream)) => Create lzstream and replace binaryReader.
+             * if (fileStream.Length != binaryReader.ReadInt64()) => Replace binaryReader.ReadInt64() to pass file length check.
+             * fileStream.Seek((long)num2, SeekOrigin.Current); => Use lzstream.Read to seek forward
+             * binaryReader.Dispose(); => Dispose lzstream before fileStream close.
+             */
             try
             {
-                using (FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
+                var matcher = new CodeMatcher(instructions, iLGenerator)
+                    .MatchForward(false, new CodeMatch(OpCodes.Newobj, AccessTools.Constructor(typeof(BinaryReader), new Type[] { typeof(FileStream) })))
+                    .Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "CreateBinaryReader"))
+                    .MatchForward(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(BinaryReader), "ReadInt64")))
+                    .Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "FileLengthRead"))
+                    .MatchForward(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(System.IDisposable), "Dispose")))
+                    .Advance(1)
+                    .Insert(new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "DisposeLzstream")))
+                    .MatchBack(false, new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(System.IO.Stream), "Seek")));
+                if (matcher.IsValid)
                 {
-                    if (!SaveUtil.IsCompressedSave(fileStream)) return false;
-                    using (var lzstream = new LZ4DecompressionStream(fileStream))
-                    using (BinaryReader binaryReader = new BinaryReader(lzstream))
-                    {
-                        if (!VerifyHeader(binaryReader))
-                        {
-                            Debug.LogError("Invalid game save file");
-                            return false;
-                        }
-                        binaryReader.ReadInt64();
-                        //long length = fileStream.Length;
-                        //if (length != binaryReader.ReadInt64())
-                        //{
-                        //	Debug.LogError("Incomplete game save");
-                        //	return false;
-                        //}
-                        int num = binaryReader.ReadInt32();
-                        if (num < 4)
-                        {
-                            Debug.LogError("Game save is too old");
-                            return false;
-                        }
-                        binaryReader.ReadInt32();
-                        binaryReader.ReadInt32();
-                        binaryReader.ReadInt32();
-
-
-                        binaryReader.ReadInt64();
-                        binaryReader.ReadInt64();
-                        int num2 = binaryReader.ReadInt32();
-                        while (num2 > 0)
-                        {
-                            num2 -= lzstream.Read(compressBuffer.outBuffer, 0, num2);
-
-                            //fileStream.Seek((long)num2, SeekOrigin.Current);
-                        }
-                        if (num >= 5)
-                        {
-                            AccountData.NULL.Import(binaryReader);
-                            binaryReader.ReadUInt64();
-                        }
-                        GameMain.data.Import(binaryReader);
-                    }
-
-                    result = true;
+                    matcher.Set(OpCodes.Call, AccessTools.Method(typeof(PatchSave), "ReadSeek"));
                 }
+                EnableDecompress = true;
+                return matcher.InstructionEnumeration();
             }
-            catch (Exception exception)
+            catch (Exception ex)
             {
-                Debug.LogException(exception);
-                result = false;
+                SaveUtil.logger.LogError("LoadCurrentGame_Transpiler failed. Mod version not compatible with game version.");
+                SaveUtil.logger.LogError(ex);
             }
-            return result;
+            return instructions;
         }
 
+        [HarmonyPatch(typeof(GameSave), "ReadHeader"), HarmonyPostfix]
+        public static GameSaveHeader ReadHeader_Postfix(GameSaveHeader __result)
+        {
+            if (UseCompressSave)
+            {
+                UseCompressSave = false;
+                var header = new CompressionGameSaveHeader(__result)
+                {
+                    IsCompressed = true
+                };
+                return header; //CompressionGameSaveHeader for UILoadGame to recognize
+            }
+            return __result;
+        }
+
+        public static BinaryReader CreateBinaryReader(FileStream fileStream)
+        {
+            if (SaveUtil.IsCompressedSave(fileStream))
+            {
+                UseCompressSave = true;
+                lzstream = new LZ4DecompressionStream(fileStream);
+                return new PeekableReader((LZ4DecompressionStream)lzstream);
+            }
+            else
+            {
+                UseCompressSave = false;
+                fileStream.Seek(0, SeekOrigin.Begin);
+                return new BinaryReader(fileStream);
+            }
+        }
+
+        public static long FileLengthRead(BinaryReader binaryReader)
+        {
+            if (UseCompressSave)
+            {
+                binaryReader.ReadInt64();
+                return lzstream.Length;
+            }
+            else
+                return binaryReader.ReadInt64();
+        }
+
+        public static long ReadSeek(FileStream fileStream, long offset, SeekOrigin origin)
+        {
+            if (UseCompressSave)
+            {
+                while (offset > 0)
+                    offset -= lzstream.Read(compressBuffer.outBuffer, 0, (int)offset);
+                return lzstream.Position;
+            }
+            else
+                return fileStream.Seek(offset, origin);
+        }
     }
 
 }

--- a/CompressSave/CompressionGameSaveHeader.cs
+++ b/CompressSave/CompressionGameSaveHeader.cs
@@ -8,5 +8,19 @@ namespace DSP_Plugin
     class CompressionGameSaveHeader:GameSaveHeader
     {
         public bool IsCompressed = false;
+
+        public CompressionGameSaveHeader() { }
+
+        public CompressionGameSaveHeader(GameSaveHeader toCopy)
+        {
+            headerVersion = toCopy.headerVersion;
+            fileSize = toCopy.fileSize;
+            gameClientVersion = toCopy.gameClientVersion;
+            gameTick = toCopy.gameTick;
+            saveTime = toCopy.saveTime;
+            themeImage = toCopy.themeImage;
+            accountData = toCopy.accountData;
+            clusterGeneration = toCopy.clusterGeneration;
+        }
     }
 }

--- a/CompressSave/CompressionGameSaveHeader.cs
+++ b/CompressSave/CompressionGameSaveHeader.cs
@@ -8,19 +8,5 @@ namespace DSP_Plugin
     class CompressionGameSaveHeader:GameSaveHeader
     {
         public bool IsCompressed = false;
-
-        public CompressionGameSaveHeader() { }
-
-        public CompressionGameSaveHeader(GameSaveHeader toCopy)
-        {
-            headerVersion = toCopy.headerVersion;
-            fileSize = toCopy.fileSize;
-            gameClientVersion = toCopy.gameClientVersion;
-            gameTick = toCopy.gameTick;
-            saveTime = toCopy.saveTime;
-            themeImage = toCopy.themeImage;
-            accountData = toCopy.accountData;
-            clusterGeneration = toCopy.clusterGeneration;
-        }
     }
 }

--- a/CompressSave/PatchUILoadGame.cs
+++ b/CompressSave/PatchUILoadGame.cs
@@ -38,13 +38,13 @@ namespace DSP_Plugin
 
                 if (localizer)
                 {
-                    localizer.stringKey = "解压/Decompress";
-                    localizer.translation = "解压/Decompress";
+                    localizer.stringKey = "解压/Decompress".Translate();
+                    localizer.translation = "解压/Decompress".Translate();
                 }
 
                 if (text)
                 {
-                    text.text = "解压/Decompress";
+                    text.text = "解压/Decompress".Translate();
                 }
 
                 decompressButton.onClick += _ =>{ 

--- a/CompressSave/PatchUILoadGame.cs
+++ b/CompressSave/PatchUILoadGame.cs
@@ -5,24 +5,58 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
+using System.Reflection.Emit;
+using System.Reflection;
 
 namespace DSP_Plugin
 {
     class PatchUILoadGame
     {
-        public static UIButton decompressButton;
+        static UIButton decompressButton;
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(UISaveGameWindow), "OnSelectedChange")]
+        [HarmonyPatch(typeof(UILoadGameWindow), "OnSelectedChange")]
+        static IEnumerable<CodeInstruction> OnSelectedChange_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var ReadHeader = typeof(GameSave).GetMethod("ReadHeader", BindingFlags.Static | BindingFlags.Public);
+            if (ReadHeader == null) return instructions;
+            var codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                var code = codes[i];
+                if (code.opcode == OpCodes.Ldstr && code.OperandIs("#,##0"))
+                {
+                    var iffalse = generator.DefineLabel();
+                    var callLabel = generator.DefineLabel();
+                    code.WithLabels(iffalse)
+                        .operand = "(N)#,##0";
+                    codes[i + 1].WithLabels(callLabel);
+                    var IL = new List<CodeInstruction> {
+                        new CodeInstruction(OpCodes.Ldloc_0),
+                        new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(CompressionGameSaveHeader),"IsCompressed")),
+                        new CodeInstruction(OpCodes.Brfalse_S,iffalse),
+                        new CodeInstruction(OpCodes.Ldstr,"(LZ4)#,##0"),
+                        new CodeInstruction(OpCodes.Br_S,callLabel),
+                    };
+                    codes.InsertRange(i, IL);
+                    break;
+                }
+            }
+
+            return codes.AsEnumerable();
+        }
 
         [HarmonyPatch(typeof(UILoadGameWindow), "OnSelectedChange"), HarmonyPostfix]
         static void OnSelectedChange(UILoadGameWindow __instance, UIButton ___loadButton, Text ___prop3Text)
         {
-            _OnOpen(__instance, ___loadButton, ___prop3Text);
             bool compressedSave = (___prop3Text != null &&___prop3Text.text.Contains("LZ4")) || (___loadButton.button.interactable == false && SaveUtil.IsCompressedSave(__instance.selected?.saveName));
-
-            decompressButton.button.interactable = compressedSave;
+            if (decompressButton)
+                decompressButton.button.interactable = compressedSave;
         }
 
         [HarmonyPatch(typeof(UILoadGameWindow), "_OnOpen"), HarmonyPostfix]
-        static void _OnOpen(UILoadGameWindow __instance, UIButton ___loadButton, Text ___prop3Text)
+        static void _OnOpen(UILoadGameWindow __instance, UIButton ___loadButton, List<UIGameSaveEntry> ___entries)
         {
             if (!decompressButton)
             {
@@ -31,7 +65,7 @@ namespace DSP_Plugin
                 decompressButton = (__instance.transform.Find("button-decompress")?.gameObject ?? GameObject.Instantiate(___loadButton.gameObject, ___loadButton.transform.parent)).GetComponent<UIButton>();
 
                 decompressButton.gameObject.name = "button-decompress";
-                decompressButton.transform.Translate(new Vector3(-1.5f, 0, 0));
+                decompressButton.transform.Translate(new Vector3(-2.0f, 0, 0));
                 decompressButton.button.image.color = new Color32(0, 0xf4, 0x92, 0x77);
                 var localizer = decompressButton.transform.Find("button-text")?.GetComponent<Localizer>();
                 var text = decompressButton.transform.Find("button-text")?.GetComponent<Text>();
@@ -41,20 +75,17 @@ namespace DSP_Plugin
                     localizer.stringKey = "解压/Decompress".Translate();
                     localizer.translation = "解压/Decompress".Translate();
                 }
-
                 if (text)
-                {
                     text.text = "解压/Decompress".Translate();
-                }
 
                 decompressButton.onClick += _ =>{ 
                     if(SaveUtil.DecompressSave(__instance.selected.saveName, out var newfileName))
                     {
                         __instance.RefreshList();
-                        var entries =  AccessTools.Field(__instance.GetType(), "entries").GetValue(__instance) as List<UIGameSaveEntry>;
-                        __instance.selected = entries.First(e => e.saveName == newfileName);
+                        __instance.selected = ___entries.First(e => e.saveName == newfileName);
                     }
                 };
+                decompressButton.button.interactable = false;
             }
         }
         

--- a/CompressSave/PatchUISaveGame.cs
+++ b/CompressSave/PatchUISaveGame.cs
@@ -41,45 +41,8 @@ namespace DSP_Plugin
             return;
         }
 
-        [HarmonyTranspiler]
-        [HarmonyPatch(typeof(UISaveGameWindow), "OnSelectedChange")]
-        [HarmonyPatch(typeof(UILoadGameWindow), "OnSelectedChange")]
-        static IEnumerable<CodeInstruction> MyTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        {
-            var ReadHeader = typeof(GameSave).GetMethod("ReadHeader", BindingFlags.Static|BindingFlags.Public);
-            if (ReadHeader == null) return instructions;
-            var codes = new List<CodeInstruction>(instructions);
-            for (int i = 0; i < codes.Count; i++)
-            {
-                var code = codes[i];
-                if (code.opcode == OpCodes.Ldstr && code.OperandIs("#,##0"))
-                {
-                    var iffalse = generator.DefineLabel();
-                    var callLabel = generator.DefineLabel();
-                    code.WithLabels(iffalse)
-                        .operand = "(N)#,##0";
-                    codes[i + 1].WithLabels(callLabel);
-                    var IL = new List<CodeInstruction> {
-                        new CodeInstruction(OpCodes.Ldloc_0),
-                        new CodeInstruction(OpCodes.Isinst,typeof(CompressionGameSaveHeader)),
-                        new CodeInstruction(OpCodes.Brfalse_S,iffalse),
-                        new CodeInstruction(OpCodes.Ldstr,"(LZ4)#,##0"),
-                        new CodeInstruction(OpCodes.Br_S,callLabel),
-                    };
-                    codes.InsertRange(i, IL);
-                    //for(int j = i -1; j< i+IL.Count + 2;j++)
-                    //{
-                    //    Console.WriteLine(codes[j]);
-                    //}
-                    break;
-                }
-            }
-
-            return codes.AsEnumerable();
-        }
-
         [HarmonyPatch(typeof(UISaveGameWindow), "OnSaveClick"), HarmonyReversePatch]
-        public static void OSaveGameAs(this UISaveGameWindow ui, int data) { }
+        static void OSaveGameAs(this UISaveGameWindow ui, int data) { }
 
         [HarmonyPatch(typeof(UISaveGameWindow), "CheckAndSetSaveButtonEnable"), HarmonyPostfix]
         static void CheckAndSetSaveButtonEnable(UISaveGameWindow __instance, UIButton ___saveButton, Text ___saveButtonText)
@@ -124,7 +87,7 @@ namespace DSP_Plugin
                 context.buttonCompress = (__instance.transform.Find("button-compress")?.gameObject??GameObject.Instantiate(___saveButton.gameObject, ___saveButton.transform.parent)).GetComponent<UIButton>();
                 
                 context.buttonCompress.gameObject.name = "button-compress";
-                context.buttonCompress.transform.Translate(new Vector3(-1.5f, 0, 0));
+                context.buttonCompress.transform.Translate(new Vector3(-2.0f, 0, 0));
                 context.buttonCompress.button.image.color = new Color32(0xfc,0x6f,00,0x77);
                 context.buttonCompressText = context.buttonCompress.transform.Find("button-text")?.GetComponent<Text>();
 

--- a/CompressSave/Properties/AssemblyInfo.cs
+++ b/CompressSave/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.5.0")]
+[assembly: AssemblyFileVersion("1.1.5.0")]

--- a/CompressSave/SaveUtil.cs
+++ b/CompressSave/SaveUtil.cs
@@ -10,14 +10,14 @@ namespace DSP_Plugin
 {
     class SaveUtil
     {
-        public static ManualLogSource logger = BepInEx.Logging.Logger.CreateLogSource("SaveCompress");
+        public static ManualLogSource logger;
         
 
         public static readonly Version VerifiedVersion = new Version
         {
             Major = 0,
-            Minor = 7,
-            Release = 18,
+            Minor = 8,
+            Release = 20,
         };
 
         public static string UnzipToFile(LZ4DecompressionStream lzStream, string fullPath)

--- a/CompressSave/app.config
+++ b/CompressSave/app.config
@@ -2,7 +2,7 @@
 <configuration>
 	<startup>
 		
-	<supportedRuntime version="v2.0.50727"/></startup>
+	<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/LZ4Wrap/LZ4CompressionStream.cs
+++ b/LZ4Wrap/LZ4CompressionStream.cs
@@ -20,7 +20,7 @@ namespace LZ4
         public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
 
-        private Stream outStream;
+        readonly Stream outStream;
 
         long totalWrite = 0;
         bool useMultiThread;
@@ -137,7 +137,7 @@ namespace LZ4
 
         void Compress_Internal()
         {
-            var readBuffer = doubleBuffer.ReadBegin();//
+            var readBuffer = doubleBuffer.ReadBegin();
             if (readBuffer.Length > 0)
             {
                 lock (outBuffer)

--- a/LZ4Wrap/LZ4DecompressionStream.cs
+++ b/LZ4Wrap/LZ4DecompressionStream.cs
@@ -15,7 +15,19 @@ namespace LZ4
 
         public override long Length => inStream.Length;
 
-        public override long Position { get=>inStream.Position; set{ long a = value; } }
+        public override long Position 
+        {   get => readPos; 
+            set
+            {
+                ResetStream();
+                byte[] tmpBuffer = new byte[1024];
+                while (value > 0)
+                {
+                    int read = Read(tmpBuffer, 0, (int)(value < 1024 ? value : 1024));
+                    value -= read;
+                }
+            } 
+        }
 
         public Stream inStream;
 
@@ -25,6 +37,8 @@ namespace LZ4
         ByteSpan dcmpBuffer;
         private bool decompressFinish = false;
         long startPos = 0;
+        long readPos = 0; //total of readlen
+
         public LZ4DecompressionStream(Stream inStream,int extraBufferSize = 512*1024)
         {
             this.inStream = inStream;
@@ -44,6 +58,7 @@ namespace LZ4
             srcBuffer.Clear();
             dcmpBuffer.Clear();
             LZ4API.ResetDecompresssCTX(dctx);
+            readPos = 0;
         }
 
         public int Fill()
@@ -91,7 +106,26 @@ namespace LZ4
                 dcmpBuffer.Position = 0;
                 dcmpBuffer.Length = (int)rt.writeLen;
             }
+            readPos += readlen;
             return readlen;
+        }
+
+        public int PeekByte()
+        {
+            if (dcmpBuffer.Length <= dcmpBuffer.Position)
+            {
+                var buffSize = Fill();
+                if (buffSize <= 0) return -1;
+
+                var rt = LZ4API.DecompressUpdateEx(dctx, dcmpBuffer, 0, dcmpBuffer.Capacity, srcBuffer, srcBuffer.Position, buffSize, null);
+                if (rt.expect < 0) throw new Exception(rt.expect.ToString());
+                if (rt.expect == 0) decompressFinish = true;
+
+                srcBuffer.Position += (int)rt.readLen;
+                dcmpBuffer.Position = 0;
+                dcmpBuffer.Length = (int)rt.writeLen;
+            }
+            return dcmpBuffer.Buffer[dcmpBuffer.Position];
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/LZ4Wrap/LZ4DecompressionStream.cs
+++ b/LZ4Wrap/LZ4DecompressionStream.cs
@@ -19,12 +19,14 @@ namespace LZ4
         {   get => readPos; 
             set
             {
-                ResetStream();
+                if (value < readPos)
+                    ResetStream();
+                else
+                    value -= readPos;
                 byte[] tmpBuffer = new byte[1024];
                 while (value > 0)
                 {
-                    int read = Read(tmpBuffer, 0, (int)(value < 1024 ? value : 1024));
-                    value -= read;
+                    value -= Read(tmpBuffer, 0, (int)(value < 1024 ? value : 1024));
                 }
             } 
         }
@@ -33,11 +35,11 @@ namespace LZ4
 
         IntPtr dctx = IntPtr.Zero;
 
-        ByteSpan srcBuffer;
-        ByteSpan dcmpBuffer;
+        readonly ByteSpan srcBuffer;
+        readonly ByteSpan dcmpBuffer;
         private bool decompressFinish = false;
-        long startPos = 0;
-        long readPos = 0; //total of readlen
+        readonly long startPos = 0;
+        long readPos = 0; //sum of readlen
 
         public LZ4DecompressionStream(Stream inStream,int extraBufferSize = 512*1024)
         {

--- a/LZ4Wrap/LZ4Wrap.projitems
+++ b/LZ4Wrap/LZ4Wrap.projitems
@@ -15,5 +15,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)LZ4CompressionStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LZ4DecompressionStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LZ4Wrap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PeekableReader.cs" />
   </ItemGroup>
 </Project>

--- a/LZ4Wrap/PeekableReader.cs
+++ b/LZ4Wrap/PeekableReader.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Security;
+
+namespace LZ4
+{
+    class PeekableReader : BinaryReader
+    {
+        LZ4DecompressionStream lzstream;
+        public PeekableReader(LZ4DecompressionStream input) : base (input)
+        {
+            lzstream = input;
+        }
+
+        public override int PeekChar()
+        {            
+            return lzstream.PeekByte();
+        }
+    }
+}


### PR DESCRIPTION
- PatchSave now use transpiler for better robustness.
- Change version check to soft warning.
- Add PeekableReader so other mods can use BinaryReader.PeekChar().
- Change LZ4DecompressionStream.Position behavior. Position setter is available now.